### PR TITLE
Enhancement: Build multi arch docker image

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -94,7 +94,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -109,7 +109,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -124,7 +124,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}

--- a/generate/templates/.github/workflows/ci-master-pr.yml.ps1
+++ b/generate/templates/.github/workflows/ci-master-pr.yml.ps1
@@ -104,7 +104,7 @@ $( $VARIANTS | % {
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: false
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -119,7 +119,7 @@ $( $VARIANTS | % {
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG_WITH_REF }}
@@ -134,7 +134,7 @@ $( $VARIANTS | % {
       uses: docker/build-push-action@v2
       with:
         context: ${{ steps.prep.outputs.CONTEXT }}
-        platforms: linux/amd64
+        platforms: linux/386,linux/amd64,linux/arm,linux/arm64,linux/s390x
         push: true
         tags: |
           ${{ github.repository }}:${{ steps.prep.outputs.VARIANT_TAG }}


### PR DESCRIPTION
Note: There's only `linux/amd64` image for`alpine:3.3` to `alpine:3.5`, see https://hub.docker.com/_/alpine?tab=tags&page=1&ordering=last_updated&name=3.5